### PR TITLE
design: 회원가입 페이지 UI 구현 및 라우터 처리

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -17,8 +17,8 @@ export function SmallImgButton({ color, size }) {
 }
 
 // 버튼 텍스트: 로그인, 다음 2가지이므로 props.content로 받기
-export function LargeButton({ content, isActive }) {
-  return <S.LargeButton isActive={isActive}>{content}</S.LargeButton>;
+export function LargeButton({ content, disabled }) {
+  return <S.LargeButton disabled={disabled}>{content}</S.LargeButton>;
 }
 
 export function MediumButton({ isFollowed }) {
@@ -26,8 +26,8 @@ export function MediumButton({ isFollowed }) {
 }
 
 // 버튼 텍스트: 저장, 업로드 2가지이므로 props.content로 받기
-export function SmallButton({ content, isActive }) {
-  return <S.SmallButton isActive={isActive}>{content}</S.SmallButton>;
+export function SmallButton({ content, disabled }) {
+  return <S.SmallButton disabled={disabled}>{content}</S.SmallButton>;
 }
 
 export function XSmallButton({ isFollowed }) {

--- a/src/components/Button/style.js
+++ b/src/components/Button/style.js
@@ -10,8 +10,12 @@ export const Button = styled.button`
 export const LargeButton = styled(Button)`
   width: 100%;
   padding: 13px 0;
-  background-color: ${({ isActive, theme }) => (isActive ? `${theme.palette.brown}` : `${theme.palette.beige}`)};
   border-radius: 44px;
+  background-color: ${({ theme }) => theme.palette.brown};
+  &:disabled {
+    cursor: default;
+    background-color: ${({ theme }) => theme.palette.beige};
+  }
 `;
 
 export const MediumButton = styled(Button)`
@@ -28,8 +32,12 @@ export const SmallButton = styled(Button)`
   width: 90px;
   max-width: 90px;
   padding: 7px 0;
-  background-color: ${({ isActive, theme }) => (isActive ? `${theme.palette.brown}` : `${theme.palette.beige}`)};
   border-radius: 32px;
+  background-color: ${({ theme }) => theme.palette.brown};
+  &:disabled {
+    cursor: default;
+    background-color: ${({ theme }) => theme.palette.beige};
+  }
 `;
 
 export const XSmallButton = styled.button`

--- a/src/pages/Signup/index.jsx
+++ b/src/pages/Signup/index.jsx
@@ -1,5 +1,22 @@
-import React from 'react';
+import { Link } from 'react-router-dom';
+import { EmailInput, PasswordInput, LargeButton, Label } from '../../components/index';
+import * as S from './style';
 
 export function Signup() {
-  return <div>Signup</div>;
+  return (
+    <S.Wrapper>
+      <S.H2>이메일로 회원가입</S.H2>
+      <S.Form>
+        <Label htmlFor='email'>이메일</Label>
+        <EmailInput id='email' placeholder='이메일 주소를 입력해 주세요.' />
+        <S.WarningText isVisible={false}>*이미 가입된 이메일 주소입니다.</S.WarningText>
+        <Label htmlFor='password'>비밀번호</Label>
+        <PasswordInput id='password' placeholder='비밀번호를 설정해 주세요.' />
+        <S.WarningText isVisible={false}>*비밀번호는 6자 이상이어야 합니다.</S.WarningText>
+        <Link to='/profile/setting'>
+          <LargeButton content='다음' disabled={true} />
+        </Link>
+      </S.Form>
+    </S.Wrapper>
+  );
 }

--- a/src/pages/Signup/style.js
+++ b/src/pages/Signup/style.js
@@ -1,1 +1,37 @@
 import styled from 'styled-components';
+
+export const Wrapper = styled.section`
+  width: calc(100% - 68px);
+  height: 100vh;
+  margin: 0 auto;
+  text-align: center;
+`;
+
+export const H2 = styled.h2`
+  margin: 30px 0 40px;
+  font-weight: 500;
+  font-size: 24px;
+  line-height: 30px;
+  color: ${({ theme }) => theme.palette.black};
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  & :nth-child(4) {
+    margin-top: 16px;
+  }
+  & button {
+    margin-top: 30px;
+  }
+`;
+
+export const WarningText = styled.strong`
+  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
+  margin-top: 6px;
+  margin-right: auto;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  color: ${({ theme }) => theme.palette.brown};
+`;


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x]  이메일로 회원가입 페이지 UI 구현
- [x]  다음 버튼 클릭 시 프로필 설정 페이지로 이동
- [x]  공통 컴포넌트의 버튼 속성 isActive를 disabled로 수정

## 🍞 참고사항

회의에서 결정된 버튼 속성의 변경을 추가로 작업하였습니다.
참고 부탁드립니다.

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->

## 💻 스크린샷

![image](https://user-images.githubusercontent.com/106213724/207753482-979d7680-e05e-4b79-9272-699f00d14744.png)
![image](https://user-images.githubusercontent.com/106213724/207753500-13b71562-d531-491b-b097-468b00a88674.png)
![image](https://user-images.githubusercontent.com/106213724/207753507-bbcdb6d5-6b32-425b-90bb-749edf5e884a.png)


Closes #15 