### PR TITLE
design: 공통 컴포넌트 - 모달창 디자인 구현

### DIFF
--- a/src/components/common/Header/index.jsx
+++ b/src/components/common/Header/index.jsx
@@ -2,13 +2,13 @@ import { Link } from 'react-router-dom';
 import * as S from './style';
 import { SmallButton } from '../Button/index';
 
-export function HeaderBasic() {
+export function HeaderBasic({ setIsVisibleModal }) {
   return (
     <S.HeaderContainer>
       <Link to={-1}>
         <S.PreviousIcon />
       </Link>
-      <S.SettingIcon />
+      <S.SettingIcon onClick={() => setIsVisibleModal(true)} />
     </S.HeaderContainer>
   );
 }

--- a/src/components/common/Modal/index.jsx
+++ b/src/components/common/Modal/index.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import * as S from './style';
 
 export function ModalLayout({ children, setIsVisibleModal }) {
@@ -19,5 +21,26 @@ export function AlertModalLayout({ alertMessage, children }) {
         <S.AlertModalLists>{children}</S.AlertModalLists>
       </S.AlertModalWindow>
     </S.AlertModalContainer>
+  );
+}
+
+export function HeaderBasicModal({ setIsVisibleModal, accountname }) {
+  const [isVisibleAlert, setIsVisibleAlert] = useState(false);
+
+  return (
+    <>
+      <ModalLayout setIsVisibleModal={setIsVisibleModal}>
+        <li>
+          <Link to={`profile/${accountname}/edit`}>설정 및 개인 정보</Link>
+        </li>
+        <li onClick={() => setIsVisibleAlert(true)}>로그아웃</li>
+      </ModalLayout>
+      {isVisibleAlert && (
+        <AlertModalLayout alertMessage='로그아웃하시겠어요?' setIsVisibleAlert={setIsVisibleAlert}>
+          <li onClick={() => setIsVisibleModal(false)}>취소</li>
+          <li>로그아웃</li>
+        </AlertModalLayout>
+      )}
+    </>
   );
 }

--- a/src/components/common/Modal/index.jsx
+++ b/src/components/common/Modal/index.jsx
@@ -65,3 +65,39 @@ export function MyPostModal({ setIsVisibleModal, postId }) {
     </>
   );
 }
+
+export function MyCommentModal({ setIsVisibleModal }) {
+  const [isVisibleAlert, setIsVisibleAlert] = useState(false);
+
+  return (
+    <>
+      <ModalLayout setIsVisibleModal={setIsVisibleModal}>
+        <li onClick={() => setIsVisibleAlert(true)}>삭제</li>
+      </ModalLayout>
+      {isVisibleAlert && (
+        <AlertModalLayout alertMessage='댓글을 삭제할까요?' setIsVisibleAlert={setIsVisibleAlert}>
+          <li onClick={() => setIsVisibleModal(false)}>취소</li>
+          <li>삭제</li>
+        </AlertModalLayout>
+      )}
+    </>
+  );
+}
+
+export function OthersPostCommentModal({ setIsVisibleModal }) {
+  const [isVisibleAlert, setIsVisibleAlert] = useState(false);
+
+  return (
+    <>
+      <ModalLayout setIsVisibleModal={setIsVisibleModal}>
+        <li onClick={() => setIsVisibleAlert(true)}>신고하기</li>
+      </ModalLayout>
+      {isVisibleAlert && (
+        <AlertModalLayout alertMessage='이 사용자를 신고하시겠어요?' setIsVisibleAlert={setIsVisibleAlert}>
+          <li onClick={() => setIsVisibleModal(false)}>취소</li>
+          <li>신고하기</li>
+        </AlertModalLayout>
+      )}
+    </>
+  );
+}

--- a/src/components/common/Modal/index.jsx
+++ b/src/components/common/Modal/index.jsx
@@ -44,3 +44,24 @@ export function HeaderBasicModal({ setIsVisibleModal, accountname }) {
     </>
   );
 }
+
+export function MyPostModal({ setIsVisibleModal, postId }) {
+  const [isVisibleAlert, setIsVisibleAlert] = useState(false);
+
+  return (
+    <>
+      <ModalLayout setIsVisibleModal={setIsVisibleModal}>
+        <li onClick={() => setIsVisibleAlert(true)}>삭제</li>
+        <li>
+          <Link to={`post/${postId}/edit`}>수정</Link>
+        </li>
+      </ModalLayout>
+      {isVisibleAlert && (
+        <AlertModalLayout alertMessage='게시글을 삭제할까요?' setIsVisibleAlert={setIsVisibleAlert}>
+          <li onClick={() => setIsVisibleModal(false)}>취소</li>
+          <li>삭제</li>
+        </AlertModalLayout>
+      )}
+    </>
+  );
+}

--- a/src/components/common/Modal/index.jsx
+++ b/src/components/common/Modal/index.jsx
@@ -1,0 +1,23 @@
+import * as S from './style';
+
+export function ModalLayout({ children, setIsVisibleModal }) {
+  return (
+    <S.ModalContainer>
+      <h2 className='sr-only'>메뉴 리스트</h2>
+      <S.ModalBackground onClick={() => setIsVisibleModal(false)} />
+      <S.ModalLists>{children}</S.ModalLists>
+    </S.ModalContainer>
+  );
+}
+
+export function AlertModalLayout({ alertMessage, children }) {
+  return (
+    <S.AlertModalContainer>
+      <h2 className='sr-only'>확인 메시지</h2>
+      <S.AlertModalWindow>
+        <S.AlertModalMessage>{alertMessage}</S.AlertModalMessage>
+        <S.AlertModalLists>{children}</S.AlertModalLists>
+      </S.AlertModalWindow>
+    </S.AlertModalContainer>
+  );
+}

--- a/src/components/common/Modal/style.js
+++ b/src/components/common/Modal/style.js
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+
+export const ModalContainer = styled.section`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+`;
+
+export const ModalBackground = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+`;
+
+export const ModalLists = styled.ul`
+  width: 390px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 0;
+  padding: 36px 0 10px;
+  border-radius: 10px 10px 0 0;
+  z-index: 200;
+  background-color: ${({ theme }) => theme.palette.white};
+
+  &::before {
+    content: '';
+    position: absolute;
+    width: 50px;
+    height: 4px;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: ${({ theme }) => theme.palette.lightGray};
+    border-radius: 5px;
+  }
+
+  & > li {
+    height: 46px;
+    padding-left: 26px;
+    font-size: 14px;
+    line-height: 46px;
+    cursor: pointer;
+  }
+`;
+
+export const AlertModalContainer = styled(ModalContainer)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+`;
+
+export const AlertModalWindow = styled.div`
+  min-width: 252px;
+  text-align: center;
+  border-radius: 10px;
+  z-index: 300;
+  background-color: ${({ theme }) => theme.palette.white};
+`;
+
+export const AlertModalMessage = styled.strong`
+  display: block;
+  padding: 22px 0;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 20px;
+  border-bottom: 0.5px solid ${({ theme }) => theme.palette.lightGray};
+`;
+export const AlertModalLists = styled.ul`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & > li {
+    width: 50%;
+    padding: 14px 0;
+    font-size: 14px;
+    line-height: 18px;
+    cursor: pointer;
+  }
+
+  & > li:last-child {
+    color: ${({ theme }) => theme.palette.brown};
+    border-left: 0.5px solid ${({ theme }) => theme.palette.lightGray};
+  }
+`;

--- a/src/components/common/Modal/style.js
+++ b/src/components/common/Modal/style.js
@@ -1,4 +1,13 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+export const slideUp = keyframes`
+ from{
+   transform: translate(-50%, 50px)
+ }
+ to{
+   transform: translateX(-50%)
+ }
+ `;
 
 export const ModalContainer = styled.section`
   position: fixed;
@@ -25,6 +34,7 @@ export const ModalLists = styled.ul`
   border-radius: 10px 10px 0 0;
   z-index: 200;
   background-color: ${({ theme }) => theme.palette.white};
+  animation: ${slideUp} 0.4s ease-out;
 
   &::before {
     content: '';

--- a/src/components/common/PostList/index.jsx
+++ b/src/components/common/PostList/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as S from './style';
 import { LikeButton } from '../LikeButton';
 
-export function PostList({ posts }) {
+export function PostList({ posts, setIsVisibleModal }) {
   return (
     <S.Container>
       {posts.map((data) => (
@@ -30,7 +30,7 @@ export function PostList({ posts }) {
             </S.LikeComment>
             <S.Date>{new Intl.DateTimeFormat('ko', { dateStyle: 'long' }).format(new Date(data.updatedAt))}</S.Date>
           </S.PostInfo>
-          <S.MoreButton>
+          <S.MoreButton onClick={() => setIsVisibleModal(true)}>
             <span className='sr-only'>더보기 버튼</span>
           </S.MoreButton>
         </S.Post>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,4 +21,4 @@ export { ProductsContainer } from './profile/ProductsContainer';
 export { PostsContainer } from './profile/PostsContainer';
 export { PostList } from './common/PostList';
 export { PostGallery } from './profile/PostGallery';
-export { HeaderBasicModal, MyPostModal } from './common/Modal';
+export { HeaderBasicModal, MyPostModal, MyCommentModal, OthersPostCommentModal } from './common/Modal';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,3 +21,4 @@ export { ProductsContainer } from './profile/ProductsContainer';
 export { PostsContainer } from './profile/PostsContainer';
 export { PostList } from './common/PostList';
 export { PostGallery } from './profile/PostGallery';
+export { HeaderBasicModal } from './common/Modal';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,4 +21,4 @@ export { ProductsContainer } from './profile/ProductsContainer';
 export { PostsContainer } from './profile/PostsContainer';
 export { PostList } from './common/PostList';
 export { PostGallery } from './profile/PostGallery';
-export { HeaderBasicModal } from './common/Modal';
+export { HeaderBasicModal, MyPostModal } from './common/Modal';

--- a/src/components/profile/PostsContainer/index.jsx
+++ b/src/components/profile/PostsContainer/index.jsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import * as S from './style';
 import { axiosPrivate } from '../../../api/apiController';
-import { PostList, PostGallery } from '../../../components';
+import { PostList, PostGallery, MyPostModal } from '../../../components';
 
 export function PostsContainer() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [posts, setPosts] = useState([]);
+  const [isVisibleModal, setIsVisibleModal] = useState(false);
   const { accountname } = useParams();
 
   useEffect(() => {
@@ -28,7 +29,7 @@ export function PostsContainer() {
           <S.ListButton onClick={() => setActiveIndex(0)} activeIndex={activeIndex}></S.ListButton>
         </S.TabItem>
       ),
-      tabContent: <PostList posts={posts} />,
+      tabContent: <PostList posts={posts} setIsVisibleModal={setIsVisibleModal} />,
     },
     {
       tabComponent: (
@@ -50,6 +51,7 @@ export function PostsContainer() {
           {tabs[activeIndex].tabContent}
         </S.Container>
       )}
+      {isVisibleModal && <MyPostModal setIsVisibleModal={setIsVisibleModal} />}
     </>
   );
 }

--- a/src/pages/ProfilePage/index.jsx
+++ b/src/pages/ProfilePage/index.jsx
@@ -1,14 +1,19 @@
-import React from 'react';
-import { UserInfoContainer, ProductsContainer, PostsContainer, HeaderBasic } from '../../components';
+import React, { useState } from 'react';
+import { UserInfoContainer, ProductsContainer, PostsContainer, HeaderBasic, HeaderBasicModal } from '../../components';
 import * as S from './style';
 
 export function ProfilePage() {
+  const [isVisibleModal, setIsVisibleModal] = useState(false);
+
   return (
-    <S.Container>
-      <HeaderBasic />
-      <UserInfoContainer />
-      <ProductsContainer />
-      <PostsContainer />
-    </S.Container>
+    <>
+      <S.Container>
+        <HeaderBasic setIsVisibleModal={setIsVisibleModal} />
+        <UserInfoContainer />
+        <ProductsContainer />
+        <PostsContainer />
+      </S.Container>
+      {isVisibleModal && <HeaderBasicModal setIsVisibleModal={setIsVisibleModal} />}
+    </>
   );
 }


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 모달창과 alert 모달창 레이아웃 구현
- [x] 모달창 애니메이션 효과 추가
- [x] 프로필 페이지 및 헤더 베이직 컴포넌트의 모달창 구현
- [x] 프로필 페이지 및 포스트리스트 컴포넌트의 모달창 구현
- [x] 댓글, 다른 사람의 게시글 및 댓글의 모달 컴포넌트 구현

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
- 프로필 페이지 내 헤더와 포스트 리스트에 모달창 구현을 완료했습니다.
- 게시물 수정 페이지 경로를 'post/:postId/edit'로 지정해뒀습니다. 추후에 해당 페이지 및 컴포넌트 작업시 라우터에 추가해야 합니다.

## 💻 스크린샷
![20221220_215703_1](https://user-images.githubusercontent.com/106213724/208796735-7b3c1066-78bd-41b1-a72b-cbd31defe2da.jpg)

![20221220_215703_2](https://user-images.githubusercontent.com/106213724/208796739-b996cebb-8397-4aa5-9d18-186a37bd02fa.jpg)

Closes #37 
