### PR TITLE
fix: 공통 컴포넌트 - 이미지 업로드 버튼 수정

### DIFF
--- a/src/components/common/Button/index.jsx
+++ b/src/components/common/Button/index.jsx
@@ -12,7 +12,7 @@ export function MediumImgButton() {
 export function SmallImgButton({ color }) {
   return (
     <>
-      <S.SmallImgButton color={color} />
+      <S.SmallImgButtonLabel color={color} />
       <S.SmallImgButtonInput />
     </>
   );

--- a/src/components/common/Button/style.js
+++ b/src/components/common/Button/style.js
@@ -79,15 +79,22 @@ export const MediumImgButtonInput = styled.input.attrs({
   clip-path: polygon(0 0, 0 0, 0, 0);
 `;
 
-export const SmallImgButton = styled.label.attrs({
+export const SmallImgButtonLabel = styled.label.attrs({
   htmlFor: 'small-img-button',
 })`
   display: inline-block;
-  width: 36px;
-  height: 36px;
-  background-image: ${({ color }) => (color === 'brown' ? `url(${SMImageBR})` : `url(${SMImageLG})`)};
-  border-radius: 50%;
-  border: none;
+  position: relative;
+  &::after {
+    content: '';
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: none;
+    background-image: ${({ color }) => (color === 'brown' ? `url(${SMImageBR})` : `url(${SMImageLG})`)};
+  }
   cursor: pointer;
 `;
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 export { MediumImgButton, SmallImgButton, LargeButton, MediumButton, SmallButton, XSmallButton } from './common/Button';
+export { SmallImgButtonLabel, SmallImgButtonInput } from './common/Button/style';
 export { Layout } from './common/Layout';
 export { Label, EmailInput, PasswordInput, NameInput, IDInput, IntroduceInput } from './common/ActiveInputs/style';
 export {


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 공통 컴포넌트 내 SmallImgButton 스타일 수정

## 🍞 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->

- 기존의 SmallImgButton 컴포넌트의 스타일을 수정 했습니다.
- background-image 속성에 있던 버튼 이미지를 가상요소 after 로 옮겼습니다.
- components 파일의 index.js 에 SmallImgButtonLabel과 SmallImgButtonInput 스타일을 export 해뒀습니다.

## 💻 스크린샷

이미지나 작업내용을 공유해주세요

Closes #45 
