### PR TITLE
feat: 팔로워/팔로잉 페이지 기능 구현

### DIFF
--- a/src/components/common/Button/index.jsx
+++ b/src/components/common/Button/index.jsx
@@ -40,6 +40,10 @@ export function SmallButton({ disabled, children, handlePostUpload, formId }) {
   );
 }
 
-export function XSmallButton({ isFollowed }) {
-  return <S.XSmallButton isFollowed={isFollowed}>{isFollowed ? '취소' : '팔로우'}</S.XSmallButton>;
+export function XSmallButton({ isFollowed, changeFollow }) {
+  return (
+    <S.XSmallButton onClick={changeFollow} isFollowed={isFollowed}>
+      {isFollowed ? '취소' : '팔로우'}
+    </S.XSmallButton>
+  );
 }

--- a/src/components/follow/Follow/index.jsx
+++ b/src/components/follow/Follow/index.jsx
@@ -1,9 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { axiosPrivate } from '../../../api/apiController';
 import { XSmallButton } from '../../common/Button';
 import * as S from './style';
 
 export function Follow({ accountname, username, intro, image, isfollow }) {
+  const [isFollowed, setIsFollowed] = useState(isfollow);
+  const myAccountName = JSON.parse(localStorage.getItem('accountname'));
   const url = `/profile/${accountname}`;
+
+  const changeFollow = async () => {
+    if (isFollowed) {
+      await axiosPrivate.delete(`/profile/${accountname}/unfollow`);
+
+      setIsFollowed(false);
+    } else {
+      await axiosPrivate.post(`/profile/${accountname}/follow`);
+
+      setIsFollowed(true);
+    }
+  };
 
   return (
     <S.Container>
@@ -14,7 +29,7 @@ export function Follow({ accountname, username, intro, image, isfollow }) {
           <S.UserIntro>{intro}</S.UserIntro>
         </S.UserInfo>
       </S.ProfileLink>
-      <XSmallButton isFollowed={isfollow} />
+      {myAccountName === accountname ? null : <XSmallButton changeFollow={changeFollow} isFollowed={isFollowed} />}
     </S.Container>
   );
 }

--- a/src/components/follow/Follow/index.jsx
+++ b/src/components/follow/Follow/index.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { XSmallButton } from '../../common/Button';
 import * as S from './style';
 
-export function Follow() {
+export function Follow({ username, intro, image, isfollow }) {
   return (
     <S.Container>
-      <S.ProfileImg />
+      <S.ProfileImg src={image} />
       <S.UserInfo>
-        <S.UserName>유저 이름</S.UserName>
-        <S.UserIntro>유저 소개</S.UserIntro>
+        <S.UserName>{username}</S.UserName>
+        <S.UserIntro>{intro}</S.UserIntro>
       </S.UserInfo>
-      <XSmallButton />
+      <XSmallButton isFollowed={isfollow} />
     </S.Container>
   );
 }

--- a/src/components/follow/Follow/index.jsx
+++ b/src/components/follow/Follow/index.jsx
@@ -2,14 +2,18 @@ import React from 'react';
 import { XSmallButton } from '../../common/Button';
 import * as S from './style';
 
-export function Follow({ username, intro, image, isfollow }) {
+export function Follow({ accountname, username, intro, image, isfollow }) {
+  const url = `/profile/${accountname}`;
+
   return (
     <S.Container>
-      <S.ProfileImg src={image} />
-      <S.UserInfo>
-        <S.UserName>{username}</S.UserName>
-        <S.UserIntro>{intro}</S.UserIntro>
-      </S.UserInfo>
+      <S.ProfileLink to={url}>
+        <S.ProfileImg src={image} />
+        <S.UserInfo>
+          <S.UserName>{username}</S.UserName>
+          <S.UserIntro>{intro}</S.UserIntro>
+        </S.UserInfo>
+      </S.ProfileLink>
       <XSmallButton isFollowed={isfollow} />
     </S.Container>
   );

--- a/src/components/follow/Follow/style.js
+++ b/src/components/follow/Follow/style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import profileTest from '../../../assets/images/basic-profile-img.png';
 
 export const Container = styled.li`
   display: flex;
@@ -16,7 +15,6 @@ export const Container = styled.li`
 `;
 
 export const ProfileImg = styled.img.attrs({
-  src: profileTest,
   alt: '프로필 이미지',
 })`
   width: 50px;

--- a/src/components/follow/Follow/style.js
+++ b/src/components/follow/Follow/style.js
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const Container = styled.li`
@@ -12,6 +13,11 @@ export const Container = styled.li`
   &:last-child {
     margin-bottom: 0;
   }
+`;
+
+export const ProfileLink = styled(Link)`
+  display: flex;
+  flex-direction: row;
 `;
 
 export const ProfileImg = styled.img.attrs({

--- a/src/pages/FollowerPage/index.jsx
+++ b/src/pages/FollowerPage/index.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { axiosPrivate } from '../../api/apiController';
 import { Follow, HeaderFollowers } from '../../components';
 import * as S from './style';
 
 export function FollowerPage() {
   const [userInfo, setUserInfo] = useState([]);
-  const accountname = JSON.parse(localStorage.getItem('accountname'));
+  const location = useLocation();
+  const accountname = location.pathname.split('/')[2];
 
   useEffect(() => {
     const getFollwer = async () => {

--- a/src/pages/FollowerPage/index.jsx
+++ b/src/pages/FollowerPage/index.jsx
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { axiosPrivate } from '../../api/apiController';
 import { Follow, HeaderFollowers } from '../../components';
 import * as S from './style';
 
 export function FollowerPage() {
+  const [userInfo, setUserInfo] = useState([]);
+  const accountname = JSON.parse(localStorage.getItem('accountname'));
+
+  useEffect(() => {
+    const getFollwer = async () => {
+      const { data } = await axiosPrivate.get(`/profile/${accountname}/follower`);
+
+      setUserInfo(data);
+    };
+
+    getFollwer();
+  }, []);
+
   return (
     <>
       <HeaderFollowers />
       <S.Container>
-        <Follow />
+        {userInfo.map((userInfo) => (
+          <Follow key={userInfo._id} {...userInfo} />
+        ))}
       </S.Container>
     </>
   );

--- a/src/pages/FollowingPage/index.jsx
+++ b/src/pages/FollowingPage/index.jsx
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { axiosPrivate } from '../../api/apiController';
 import { Follow, HeaderFollowings } from '../../components';
 import * as S from './style';
 
 export function FollowingPage() {
+  const [userInfo, setUserInfo] = useState([]);
+  const accountname = JSON.parse(localStorage.getItem('accountname'));
+
+  useEffect(() => {
+    const getFollwing = async () => {
+      const { data } = await axiosPrivate.get(`/profile/${accountname}/following`);
+
+      setUserInfo(data);
+    };
+
+    getFollwing();
+  }, []);
+
   return (
     <>
       <HeaderFollowings />
       <S.Container>
-        <Follow />
+        {userInfo.map((userInfo) => (
+          <Follow key={userInfo._id} {...userInfo} />
+        ))}
       </S.Container>
     </>
   );

--- a/src/pages/FollowingPage/index.jsx
+++ b/src/pages/FollowingPage/index.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { axiosPrivate } from '../../api/apiController';
 import { Follow, HeaderFollowings } from '../../components';
 import * as S from './style';
 
 export function FollowingPage() {
   const [userInfo, setUserInfo] = useState([]);
-  const accountname = JSON.parse(localStorage.getItem('accountname'));
+  const location = useLocation();
+  const accountname = location.pathname.split('/')[2];
 
   useEffect(() => {
     const getFollwing = async () => {


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 팔로잉, 팔로워 목록 axios 통신
- [x] user info 누르면 해당 사용자 프로필로 이동
- [x] 팔로우 버튼 클릭 시 목록에 해당 사용자 추가/삭제 (팔로우 상태 변경)
- [x] 팔로워 및 팔로잉 목록에 내가 표시될 경우 팔로우 버튼 나타나지 않도록 구현

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->


## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
https://user-images.githubusercontent.com/96907832/209518071-100db04f-ef24-4f76-95d2-2672828392da.MP4



Closes #61 
