### PR TITLE
fix: 공통 컴포넌트 Post 네비바에 가려지는 이슈 해결

### DIFF
--- a/src/components/common/PostList/index.jsx
+++ b/src/components/common/PostList/index.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as S from './style';
 import { Post } from '../Post';
 
 export function PostList({ posts, setIsVisibleModal, setPostId }) {
+  const postListCont = useRef(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (!postListCont.current) return;
+    setHeight(postListCont.current.getBoundingClientRect().height);
+  }, [posts]);
+
   return (
-    <S.Container>
+    <S.Container ref={postListCont} height={height}>
       {posts.map((data) => (
         <Post key={data.id} data={data} setIsVisibleModal={setIsVisibleModal} setPostId={setPostId} />
       ))}

--- a/src/components/common/PostList/style.js
+++ b/src/components/common/PostList/style.js
@@ -1,7 +1,13 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.section`
   padding: 16px;
+
+  ${({ height }) =>
+    height >= window.innerHeight - 107 &&
+    css`
+      padding-bottom: 89px;
+    `}
 
   & article + article {
     margin-top: 20px;

--- a/src/components/profile/PostGallery/index.jsx
+++ b/src/components/profile/PostGallery/index.jsx
@@ -1,10 +1,19 @@
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import * as S from './style';
 
 export function PostGallery({ posts }) {
+  const galleryCont = useRef(null);
+
+  const [bottom, setbottom] = useState(0);
+
+  useEffect(() => {
+    if (!galleryCont.current) return;
+    setbottom(galleryCont.current.getBoundingClientRect().bottom);
+  }, [posts]);
+
   return (
-    <S.Container>
+    <S.Container ref={galleryCont} bottom={bottom}>
       <S.GalleryList>
         {posts.map(
           (data) =>

--- a/src/components/profile/PostGallery/style.js
+++ b/src/components/profile/PostGallery/style.js
@@ -1,9 +1,15 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
   max-width: 390px;
   width: 100%;
   padding: 16px;
+
+  ${({ bottom }) =>
+    bottom >= window.document.documentElement.clientHeight - 59 &&
+    css`
+      padding-bottom: 89px;
+    `}
 `;
 
 export const GalleryList = styled.ul`

--- a/src/components/profile/PostsContainer/style.js
+++ b/src/components/profile/PostsContainer/style.js
@@ -6,7 +6,6 @@ import PostGalleryIconOff from '../../../assets/icons/icon-post-gallery-off.svg'
 
 export const Container = styled.section`
   background-color: ${({ theme }) => theme.palette.white};
-  padding-bottom: 60px;
 `;
 
 export const TabContainer = styled.div`


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 공통 컴포넌트 Post 네비바에 가려지는 이슈 해결
- [x] 프로필 페이지 PostsContainer 높이에 따라 padding bottom 늘어나도록 수정

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->

## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
<img width="388" alt="스크린샷 2022-12-27 오후 11 45 50" src="https://user-images.githubusercontent.com/79586634/209682811-51ef623d-dcec-441c-88f4-26f42b59540c.png">
<img width="386" alt="스크린샷 2022-12-27 오후 11 46 14" src="https://user-images.githubusercontent.com/79586634/209682820-757f6ff0-01c8-4c23-b347-e84068b2f02c.png">

Closes #70 
