### PR TITLE
fix: 프로필 미설정 시 기본 이미지 변경

### DIFF
--- a/src/components/common/Post/index.jsx
+++ b/src/components/common/Post/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import * as S from './style';
 import { LikeButton } from '../LikeButton';
+import basicProfile from '../../../assets/images/basic-profile-img.png';
 
 export function Post({ data, setIsVisibleModal, setPostId, setIsMyPost }) {
   const accountname = JSON.parse(localStorage.getItem('accountname'));
+  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}/Ellipse.png`;
 
   const handleMoreBtn = (postId) => {
     setIsVisibleModal(true);
@@ -18,12 +20,20 @@ export function Post({ data, setIsVisibleModal, setPostId, setIsMyPost }) {
     }
   };
 
+  const renderProfileImage = () => {
+    let profileImage = basicProfile;
+
+    if (data.author.image !== BASIC_PROFILE_URL) profileImage = data.author.image;
+
+    return <S.ProfileImg src={profileImage} />;
+  };
+
   return (
     <S.Post key={data.id}>
       <h3 className='sr-only'>게시글</h3>
       <S.AuthorInfo>
         <h4 className='sr-only'>게시글 작성자 정보</h4>
-        <S.ProfileImg src={data.author.image} />
+        {renderProfileImage()}
         <S.TextContainer>
           <S.UserName>{data.author.username}</S.UserName>
           <S.AccountName>@{data.author.accountname}</S.AccountName>

--- a/src/components/follow/Follow/index.jsx
+++ b/src/components/follow/Follow/index.jsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import { axiosPrivate } from '../../../api/apiController';
 import { XSmallButton } from '../../common/Button';
 import * as S from './style';
+import basicProfile from '../../../assets/images/basic-profile-img.png';
 
 export function Follow({ accountname, username, intro, image, isfollow }) {
   const [isFollowed, setIsFollowed] = useState(isfollow);
   const myAccountName = JSON.parse(localStorage.getItem('accountname'));
   const url = `/profile/${accountname}`;
+  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}/Ellipse.png`;
 
   const changeFollow = async () => {
     if (isFollowed) {
@@ -20,10 +22,18 @@ export function Follow({ accountname, username, intro, image, isfollow }) {
     }
   };
 
+  const renderProfileImage = () => {
+    let profileImage = basicProfile;
+
+    if (image !== BASIC_PROFILE_URL) profileImage = image;
+
+    return <S.ProfileImg src={profileImage} />;
+  };
+
   return (
     <S.Container>
       <S.ProfileLink to={url}>
-        <S.ProfileImg src={image} />
+        {renderProfileImage()}
         <S.UserInfo>
           <S.UserName>{username}</S.UserName>
           <S.UserIntro>{intro}</S.UserIntro>

--- a/src/components/profile/UserInfoContainer/index.jsx
+++ b/src/components/profile/UserInfoContainer/index.jsx
@@ -5,14 +5,14 @@ import { MediumButton } from '../../common/Button';
 import { ReactComponent as ShareIcon } from '../../../assets/icons/icon-share.svg';
 import { ReactComponent as ChatIcon } from '../../../assets/icons/icon-chat.svg';
 import { axiosPrivate } from '../../../api/apiController';
-import ProfileImg from '../../../assets/images/basic-profile-img.png';
+import basicProfile from '../../../assets/images/basic-profile-img.png';
 
 export function UserInfoContainer() {
   const [userInfo, setUserInfo] = useState({});
   const { accountname } = useParams();
 
   const localAccountName = JSON.parse(localStorage.getItem('accountname'));
-  const basicImg = 'http://146.56.183.55:5050/Ellipse.png';
+  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}/Ellipse.png`;
 
   useEffect(() => {
     const getUserInfo = async () => {
@@ -28,9 +28,17 @@ export function UserInfoContainer() {
 
   const { username, accountname: _accountname, intro, followerCount, followingCount, image } = userInfo;
 
+  const renderProfileImage = () => {
+    let profileImage = basicProfile;
+
+    if (image !== BASIC_PROFILE_URL) profileImage = image;
+
+    return <S.ProfileImage src={profileImage} />;
+  };
+
   return (
     <S.Container>
-      {image !== basicImg ? <S.ProfileImage src={image} /> : <S.ProfileImage src={ProfileImg} />}
+      {renderProfileImage()}
       <S.AccountName>{username}</S.AccountName>
       <S.AccountId>@{_accountname}</S.AccountId>
       <S.Intro>{intro}</S.Intro>


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 포스트 프로필 기본 이미지 처리
- [x] 팔로우 프로필 기본 이미지 처리
- [x] 프로필 탭 기본 이미지 함수형 처리

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->


## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
<img width="391" alt="스크린샷 2022-12-30 오후 6 12 59" src="https://user-images.githubusercontent.com/96907832/210053839-78acb8d2-89af-435a-ac1f-fecf7e9b464f.png"><img width="391" alt="스크린샷 2022-12-30 오후 6 13 52" src="https://user-images.githubusercontent.com/96907832/210053905-8a2da461-ea69-40e1-8612-e9126ee45ee5.png">


Closes #83 
