### PR TITLE
feat: 댓글 프로필 이미지 axios 처리 및 프로필 이동 구현

### DIFF
--- a/src/components/comment/Comment/index.jsx
+++ b/src/components/comment/Comment/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import * as S from './style';
 import { timeForToday } from '../../../utils/timeForToday';
 
 export function Comment({ comment, setIsVisibleModal, setIsMyComment, setCommentId }) {
   const accountname = JSON.parse(localStorage.getItem('accountname'));
+  const userURL = `/profile/${comment.author.accountname}`;
 
   const handleMoreBtn = (commentId) => {
     setIsVisibleModal(true);
@@ -20,9 +22,13 @@ export function Comment({ comment, setIsVisibleModal, setIsMyComment, setComment
     <S.CommentItem>
       <S.AuthorInfo>
         <h4 className='sr-only'>게시글 작성자 정보</h4>
-        <S.ProfileImg src={comment.author.image} />
+        <Link to={userURL}>
+          <S.ProfileImg src={comment.author.image} />
+        </Link>
         <S.TextContainer>
-          <S.UserName>{comment.author.username}</S.UserName>
+          <Link to={userURL}>
+            <S.UserName>{comment.author.username}</S.UserName>
+          </Link>
           <S.Time>{timeForToday(comment.createdAt)}</S.Time>
         </S.TextContainer>
       </S.AuthorInfo>

--- a/src/components/comment/CommentInput/index.jsx
+++ b/src/components/comment/CommentInput/index.jsx
@@ -1,10 +1,43 @@
 import React, { useState, useEffect } from 'react';
 import * as S from './style';
 import { axiosPrivate } from '../../../api/apiController';
+import basicProfile from '../../../assets/images/basic-profile-img.png';
 
 export function CommentInput({ getComments, post, setPost, postId }) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [profile, setProfile] = useState('');
   const [input, setInput] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
+  const accountname = JSON.parse(localStorage.getItem('accountname'));
+  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}`;
+
+  const getProfile = async () => {
+    setIsLoading(true);
+    try {
+      const {
+        data: {
+          profile: { image },
+        },
+      } = await axiosPrivate.get(`/profile/${accountname}`);
+
+      setProfile(image);
+    } catch (e) {
+      console.log(e);
+    }
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    getProfile();
+  }, []);
+
+  const renderProfileImage = () => {
+    let profileImage = basicProfile;
+
+    if (profile !== BASIC_PROFILE_URL) profileImage = profile;
+
+    return <S.ProfileImage src={profileImage} />;
+  };
 
   const handleUpload = async () => {
     const {
@@ -30,7 +63,7 @@ export function CommentInput({ getComments, post, setPost, postId }) {
 
   return (
     <S.Container>
-      <S.ProfileImage />
+      {renderProfileImage()}
       <S.Input value={input} onChange={(e) => setInput(e.target.value)} />
       <S.Button disabled={isDisabled} onClick={handleUpload}>
         게시

--- a/src/components/comment/CommentInput/index.jsx
+++ b/src/components/comment/CommentInput/index.jsx
@@ -9,7 +9,7 @@ export function CommentInput({ getComments, post, setPost, postId }) {
   const [input, setInput] = useState('');
   const [isDisabled, setIsDisabled] = useState(true);
   const accountname = JSON.parse(localStorage.getItem('accountname'));
-  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}`;
+  const BASIC_PROFILE_URL = `${process.env.REACT_APP_SERVER_URL}/Ellipse.png`;
 
   const getProfile = async () => {
     setIsLoading(true);

--- a/src/components/comment/CommentInput/style.js
+++ b/src/components/comment/CommentInput/style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import BasicProfileImage from '../../../assets/images/basic-profile-img.png';
 
 export const Container = styled.section`
   width: min(390px, 100%);
@@ -16,12 +15,12 @@ export const Container = styled.section`
 `;
 
 export const ProfileImage = styled.img.attrs({
-  src: BasicProfileImage,
   alt: '사용자 프로필 이미지',
 })`
   width: 36px;
   height: 36px;
   border-radius: 18px;
+  object-fit: cover;
 `;
 
 export const Input = styled.input.attrs({


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 댓글 프로필 이미지 axios 처리
- [x] 프로필 이미지 혹은 계정 이름 클릭 시 해당 계정 프로필 페이지로 이동 구현

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->


## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
<img width="387" alt="스크린샷 2022-12-31 오전 1 57 08" src="https://user-images.githubusercontent.com/96907832/210094649-a05b4f4f-3e25-4b9d-bd7e-461c7b0b83d8.png">


Closes #97 
