### PR TITLE
fix: 게시글이 적어도 스크롤되는 현상 해결

### DIFF
--- a/src/components/comment/Comment/style.js
+++ b/src/components/comment/Comment/style.js
@@ -57,6 +57,7 @@ export const Content = styled.p`
   font-weight: 400;
   font-size: 14px;
   line-height: 18px;
+  word-wrap: break-word;
 `;
 
 export const MoreButton = styled.button`

--- a/src/components/comment/CommentList/index.jsx
+++ b/src/components/comment/CommentList/index.jsx
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import * as S from './style';
 import { Comment, OthersPostCommentModal, MyCommentModal } from '../../../components';
+import useHeight from '../../../hooks/useHeight';
 
-export function CommentList({ height, postId, getComments, comments, post, setPost }) {
+export function CommentList({ postId, getComments, comments, post, setPost }) {
   const [isVisibleModal, setIsVisibleModal] = useState(false);
   const [isMyComment, setIsMyComment] = useState(false);
   const [commentId, setCommentId] = useState('');
 
+  const [container, height] = useHeight(comments);
+
   return (
     <>
-      <S.CommentList height={height}>
+      <S.CommentList ref={container} height={height}>
         {comments.map((comment) => (
           <Comment
             key={comment.id}

--- a/src/components/comment/CommentList/style.js
+++ b/src/components/comment/CommentList/style.js
@@ -6,7 +6,7 @@ export const CommentList = styled.ul`
   ${({ height }) =>
     height >= window.innerHeight - 62 &&
     css`
-      padding-bottom: 82px;
+      padding-bottom: 92px;
     `}
 
   & li + li {

--- a/src/components/common/Post/style.js
+++ b/src/components/common/Post/style.js
@@ -5,6 +5,7 @@ import ChatIcon from '../../../assets/icons/icon-chat.svg';
 import MoreIcon from '../../../assets/icons/icon-more-vertical.svg';
 
 export const Post = styled.article`
+  width: 100%;
   position: relative;
 `;
 
@@ -52,6 +53,7 @@ export const Content = styled.p`
   font-size: 14px;
   line-height: 18px;
   margin-bottom: 16px;
+  word-wrap: break-word;
 `;
 
 export const Img = styled.img`

--- a/src/components/common/PostList/index.jsx
+++ b/src/components/common/PostList/index.jsx
@@ -8,7 +8,7 @@ export function PostList({ posts, setIsVisibleModal, setPostId }) {
 
   useEffect(() => {
     if (!postListCont.current) return;
-    setHeight(postListCont.current.getBoundingClientRect().height);
+    setHeight(postListCont.current.getBoundingClientRect().bottom);
   }, [posts]);
 
   return (

--- a/src/components/common/PostList/index.jsx
+++ b/src/components/common/PostList/index.jsx
@@ -1,18 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
 import * as S from './style';
 import { Post } from '../Post';
+import useHeight from '../../../hooks/useHeight';
 
 export function PostList({ posts, setIsVisibleModal, setPostId }) {
-  const postListCont = useRef(null);
-  const [height, setHeight] = useState(0);
-
-  useEffect(() => {
-    if (!postListCont.current) return;
-    setHeight(postListCont.current.getBoundingClientRect().bottom);
-  }, [posts]);
+  const [container, height] = useHeight(posts);
 
   return (
-    <S.Container ref={postListCont} height={height}>
+    <S.Container ref={container} height={height}>
       {posts.map((data) => (
         <Post key={data.id} data={data} setIsVisibleModal={setIsVisibleModal} setPostId={setPostId} />
       ))}

--- a/src/components/common/PostList/style.js
+++ b/src/components/common/PostList/style.js
@@ -1,11 +1,10 @@
 import styled, { css } from 'styled-components';
 
 export const Container = styled.section`
-  min-height: 100vh;
   padding: 16px;
 
   ${({ height }) =>
-    height >= window.innerHeight - 107 &&
+    height >= window.innerHeight - 59 &&
     css`
       padding-bottom: 89px;
     `}

--- a/src/components/profile/PostGallery/index.jsx
+++ b/src/components/profile/PostGallery/index.jsx
@@ -1,19 +1,15 @@
-import React, { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import useHeight from '../../../hooks/useHeight';
 import * as S from './style';
 
 export function PostGallery({ posts }) {
-  const galleryCont = useRef(null);
+  const isImage = posts.filter((post) => post.image);
+  const [container, height] = useHeight(posts);
 
-  const [bottom, setbottom] = useState(0);
-
-  useEffect(() => {
-    if (!galleryCont.current) return;
-    setbottom(galleryCont.current.getBoundingClientRect().bottom);
-  }, [posts]);
+  if (!isImage.length) return;
 
   return (
-    <S.Container ref={galleryCont} bottom={bottom}>
+    <S.Container ref={container} bottom={height}>
       <S.GalleryList>
         {posts.map(
           (data) =>

--- a/src/components/profile/PostsContainer/index.jsx
+++ b/src/components/profile/PostsContainer/index.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import * as S from './style';
 import { axiosPrivate } from '../../../api/apiController';
 import { PostList, PostGallery, MyPostModal } from '../../../components';
-import { useIntersect } from '../../../hooks/useIntersect';
+import useIntersect from '../../../hooks/useIntersect';
 
 export function PostsContainer() {
   const [activeIndex, setActiveIndex] = useState(0);

--- a/src/hooks/useHeight.js
+++ b/src/hooks/useHeight.js
@@ -1,0 +1,14 @@
+import { useState, useEffect, useRef } from 'react';
+
+export default function useHeight(data) {
+  const container = useRef(null);
+
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (!container.current) return;
+    setHeight(container.current.getBoundingClientRect().bottom);
+  }, [data]);
+
+  return [container, height];
+}

--- a/src/hooks/useIntersect.js
+++ b/src/hooks/useIntersect.js
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 
-export const useIntersect = (onIntersect, options = { threshold: 1 }) => {
+export default function useIntersect(onIntersect, options = { threshold: 1 }) {
   const ref = useRef(null);
 
   const callback = useCallback(
@@ -21,4 +21,4 @@ export const useIntersect = (onIntersect, options = { threshold: 1 }) => {
   }, [ref, options, callback]);
 
   return ref;
-};
+}

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { PostList, NoFollowings, HeaderMain, OthersPostCommentModal } from '../../components';
 import { axiosPrivate } from '../../api/apiController';
-import { useIntersect } from '../../hooks/useIntersect';
+import useIntersect from '../../hooks/useIntersect';
 
 export function HomePage() {
   const [isVisibleModal, setIsVisibleModal] = useState(false);

--- a/src/pages/PostPage/index.jsx
+++ b/src/pages/PostPage/index.jsx
@@ -1,17 +1,14 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { axiosPrivate } from '../../api/apiController';
 import { HeaderBasic, HeaderBasicModal, PostContainer, CommentList, CommentInput } from '../../components';
 
 export function PostPage() {
-  const container = useRef(null);
-
   const { postId: id } = useParams();
 
   const [postId, setPostId] = useState(id);
   const [post, setPost] = useState('');
   const [comments, setComments] = useState([]);
-  const [height, setHeight] = useState(0);
   const [isVisibleModal, setIsVisibleModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -48,25 +45,13 @@ export function PostPage() {
     getComments();
   }, []);
 
-  useEffect(() => {
-    if (!container.current) return;
-    setHeight(container.current.clientHeight);
-  }, [comments]);
-
   return (
     <>
-      <section ref={container}>
+      <section>
         <h2 className='sr-only'>게시글 페이지</h2>
         <HeaderBasic setIsVisibleModal={setIsVisibleModal} />
         <PostContainer postId={postId} setPostId={setPostId} post={post} getUserPost={getUserPost} />
-        <CommentList
-          height={height}
-          postId={postId}
-          getComments={getComments}
-          comments={comments}
-          post={post}
-          setPost={setPost}
-        />
+        <CommentList postId={postId} getComments={getComments} comments={comments} post={post} setPost={setPost} />
       </section>
       <CommentInput getComments={getComments} post={post} setPost={setPost} postId={postId} />
       {isVisibleModal && <HeaderBasicModal setIsVisibleModal={setIsVisibleModal} />}


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] 게시글이 적어도 스크롤되는 현상 해결
- [x]  useHeight 훅 추가해 게시글, 댓글, 이미지 갤러리에서 import하여 사용하기
- [x] 게시글/댓글 내용이 컨테이너 넘어가는 현상 수정

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
게시글, 댓글, 프로필 페이지 이미지 갤러리 리스트들의 전체 height를 파악하기 위한 useHeight 커스텀 훅을 따로 분리했습니다.

## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->

Closes #124 
