### PR TITLE
[fix] 포스트 수정 페이지 textarea 오류 및 빈 이미지 불러오는 현상 해결

### DIFF
--- a/src/api/post/addPost.js
+++ b/src/api/post/addPost.js
@@ -9,7 +9,7 @@ export async function addPost(text, images) {
       },
     });
 
-    return data.message;
+    return data;
   } catch (e) {
     console.log(e);
   }

--- a/src/api/post/updatePost.js
+++ b/src/api/post/updatePost.js
@@ -2,12 +2,14 @@ import { axiosPrivate } from '../apiController';
 
 export async function updatePost(postId, text, images) {
   try {
-    await axiosPrivate.put(`/post/${postId}`, {
+    const { data } = await axiosPrivate.put(`/post/${postId}`, {
       post: {
         content: text,
         image: images,
       },
     });
+
+    return data;
   } catch (e) {
     console.log(e);
   }

--- a/src/components/postEdit/PostEditForm/index.jsx
+++ b/src/components/postEdit/PostEditForm/index.jsx
@@ -36,7 +36,12 @@ export function PostEditForm() {
     const { content, image } = await getPost(postId);
 
     setText(content);
-    setPostImg(image.split(','));
+
+    if (!image) {
+      setPostImg([]);
+    } else {
+      setPostImg(image.split(','));
+    }
 
     setIsLoading(false);
   };
@@ -114,7 +119,7 @@ export function PostEditForm() {
               <h4 className='sr-only'>이미지 업로드 버튼</h4>
               <MediumImgButton />
             </S.ImgUploadButton>
-            {postImg.length === 0 ? null : <PhotoUploadList imgSrc={postImg} setPostImg={setPostImg} />}
+            {postImg.length === 0 ? <></> : <PhotoUploadList imgSrc={postImg} setPostImg={setPostImg} />}
           </S.Form>
         </S.PostWrite>
       </S.Container>

--- a/src/components/postEdit/PostEditForm/index.jsx
+++ b/src/components/postEdit/PostEditForm/index.jsx
@@ -54,11 +54,18 @@ export function PostEditForm() {
     return <S.ProfileImg src={profileImage} />;
   };
 
-  const handleTextArea = (e) => {
-    textRef.current.style.height = 'auto';
-    textRef.current.style.height = `${textRef.current.scrollHeight}px`;
+  const handleText = (e) => {
     setText(e.target.value);
   };
+
+  const handleTextArea = () => {
+    textRef.current.style.height = 'auto';
+    textRef.current.style.height = `${textRef.current.scrollHeight}px`;
+  };
+
+  useEffect(() => {
+    handleTextArea();
+  }, [text]);
 
   const handleGetImageUrl = async (e) => {
     if (postImg.length < MAX_UPLOAD) {
@@ -102,7 +109,7 @@ export function PostEditForm() {
         <S.PostWrite>
           <h3 className='sr-only'>게시글 작성 form</h3>
           <S.Form>
-            <S.ContentInput onInput={handleTextArea} ref={textRef} defaultValue={text} />
+            <S.ContentInput onInput={handleText} ref={textRef} defaultValue={text} />
             <S.ImgUploadButton onChange={handleGetImageUrl}>
               <h4 className='sr-only'>이미지 업로드 버튼</h4>
               <MediumImgButton />

--- a/src/components/postUpload/PostUploadForm/index.jsx
+++ b/src/components/postUpload/PostUploadForm/index.jsx
@@ -98,7 +98,7 @@ export function PostUploadForm() {
               <h4 className='sr-only'>이미지 업로드 버튼</h4>
               <MediumImgButton />
             </S.ImgUploadButton>
-            {postImg.length === 0 ? null : <PhotoUploadList imgSrc={postImg} setPostImg={setPostImg} />}
+            {postImg.length === 0 ? <></> : <PhotoUploadList imgSrc={postImg} setPostImg={setPostImg} />}
           </S.Form>
         </S.PostWrite>
       </S.Container>


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x] textarea 높이값 인식하지 못하는 현상 해결
- [x] 이미지 없는 게시글 수정 시 이미지 틀 나타나는 현상 해결

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
1. textarea 높이값 인식하지 못하는 현상
- 렌더링 시 textarea의 값을 계산해 주는 로직을 실행해 주지 않아서 생기는 현상으로 판단되어 페이지 렌더링 시 textarea의 높이값을 계산해 주는 함수를 실행하여 해결하였습니다.

2. 이미지 없는 게시글 수정 시 이미지 틀 나타나는 현상
- 이미지가 들어오지 않을 때에도 `setPostImg(image.split(','))`가 실행되어 postImg에 담기기 때문에 빈 배열이 아니게 되어 발생하는 현상으로 판단되어 이미지 값이 들어오지 않을 때에는 빈 배열로 초기화해주는 로직을 추가하였습니다.

3. 지난 회의 시 API 로직 return 값에 대한 논의가 있었으나 현재 return의 구조를 통일하는게 좋을 것 같다 판단되어 제가 작업한 부분의 return값의 형태를 다른 분들과 통일하였습니다.


## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->

Closes #160 
