### PR TITLE
refactor: 이미지 업로드 압축 및 상품 등록/수정 페이지 세부 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.2.1",
+        "browser-image-compression": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.41.0",
@@ -5500,6 +5501,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
+      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -17180,6 +17189,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -22049,6 +22063,14 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "browser-image-compression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.0.tgz",
+      "integrity": "sha512-kBlkZo13yOOfcmrPW0M0K/UdZPogIQj2gRvXIM3FktAnfW6VRq9aY2RI+F6O0x6DMj1Xm+WLGgWcFK8Fu/ddnw==",
+      "requires": {
+        "uzip": "0.20201231.0"
       }
     },
     "browser-process-hrtime": {
@@ -30371,6 +30393,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.2.1",
+    "browser-image-compression": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.41.0",

--- a/src/api/imgUpload/addImage.js
+++ b/src/api/imgUpload/addImage.js
@@ -1,11 +1,14 @@
 import { axiosImg, BASE_URL } from '../apiController';
+import { imageResize } from './imageResize';
 
 export async function addImage(file) {
-  const formData = new FormData();
-
-  formData.append('image', file);
-
   try {
+    const newFile = await imageResize(file);
+
+    const formData = new FormData();
+
+    formData.append('image', newFile);
+
     const {
       data: { filename },
     } = await axiosImg.post('/image/uploadfile', formData);

--- a/src/api/imgUpload/imageResize.js
+++ b/src/api/imgUpload/imageResize.js
@@ -1,0 +1,20 @@
+import imageCompression from 'browser-image-compression';
+
+export async function imageResize(file) {
+  const options = {
+    maxSizeMB: 0.2,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  };
+
+  try {
+    const compressedFile = await imageCompression(file, options);
+    const newFile = new File([compressedFile], `${compressedFile.name}`, {
+      type: compressedFile.type,
+    });
+
+    return newFile;
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/src/api/product/addProduct.js
+++ b/src/api/product/addProduct.js
@@ -2,7 +2,7 @@ import { axiosPrivate } from '../apiController';
 
 export async function addProduct(itemName, price, link, itemImage) {
   try {
-    await axiosPrivate.post('/product', {
+    const { data } = await axiosPrivate.post('/product', {
       product: {
         itemName,
         price,
@@ -10,6 +10,8 @@ export async function addProduct(itemName, price, link, itemImage) {
         itemImage,
       },
     });
+
+    return data;
   } catch (e) {
     console.log(e);
   }

--- a/src/api/product/updateProduct.js
+++ b/src/api/product/updateProduct.js
@@ -2,7 +2,7 @@ import { axiosPrivate } from '../apiController';
 
 export async function updateProduct(productId, itemName, price, link, itemImage) {
   try {
-    await axiosPrivate.put(`/product/${productId}`, {
+    const { data } = await axiosPrivate.put(`/product/${productId}`, {
       product: {
         itemName,
         price,
@@ -10,6 +10,8 @@ export async function updateProduct(productId, itemName, price, link, itemImage)
         itemImage,
       },
     });
+
+    return data;
   } catch (e) {
     console.log(e);
   }

--- a/src/components/product/ProductForm/style.js
+++ b/src/components/product/ProductForm/style.js
@@ -43,6 +43,7 @@ export const Image = styled.img.attrs({
   width: 100%;
   height: 100%;
   object-fit: cover;
+  background-color: ${({ theme }) => theme.palette.white};
 `;
 
 export const ImageInput = styled(SmallImgButtonInput)``;


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x]  이미지 압축 API 추가
- [x]  png 이미지 백그라운드 컬러 설정
- [x]  axios return 문 통일

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
라이브러리 'browser-image-compression' 을 사용하여 imageResize API를 추가 했습니다.
1개의 이미지를 실행한 결과, 이미지 업로드 시간이 단축되었고, 용량이 216.8 KB에서 147.1 KB로 줄었습니다.
아래 사진 참고 부탁드려요.

## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
![image](https://user-images.githubusercontent.com/106213724/213848755-15c60e02-dbf5-4294-8b86-009e5b2e9ddd.png)
![image](https://user-images.githubusercontent.com/106213724/213848758-25750415-df7e-4cba-9655-7aa0f8dda983.png)


Closes #169 
