### PR TITLE
fix: 홈페이지 무한 스크롤 시 맨위로 올라가는 현상 해결 및 로딩 컴포넌트 추가

### DIFF
--- a/src/components/common/Loading/index.jsx
+++ b/src/components/common/Loading/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import * as S from './style';
+
+export function Loading() {
+  return <S.Container>로딩중...</S.Container>;
+}

--- a/src/components/common/Loading/index.jsx
+++ b/src/components/common/Loading/index.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
+import Logo from '../../../assets/images/symbol-logo.webp';
+
 import * as S from './style';
 
 export function Loading() {
-  return <S.Container>로딩중...</S.Container>;
+  return (
+    <S.Container>
+      <S.Image src={Logo} alt='빵굿이' />
+      <S.Text>로딩중...</S.Text>
+    </S.Container>
+  );
 }

--- a/src/components/common/Loading/style.js
+++ b/src/components/common/Loading/style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Container = styled.section`
+  min-height: calc(100vh - 59px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.palette.white};
+`;

--- a/src/components/common/Loading/style.js
+++ b/src/components/common/Loading/style.js
@@ -1,9 +1,19 @@
 import styled from 'styled-components';
 
 export const Container = styled.section`
-  min-height: calc(100vh - 59px);
+  min-height: calc(100vh - 108px);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   background-color: ${({ theme }) => theme.palette.white};
+`;
+
+export const Image = styled.img`
+  width: 165px;
+`;
+
+export const Text = styled.h3`
+  margin-top: 10px;
+  font-size: 18px;
 `;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,6 +21,7 @@ export {
   HeaderFollowings,
 } from './common/Header';
 export { Navbar } from './common/Navbar';
+export { Loading } from './common/Loading';
 export { LoginButtons } from './start/LoginButtons';
 export { LoginForm } from './login/LoginForm';
 export { SignupForm } from './signup/SignupForm';

--- a/src/components/post/Post/index.jsx
+++ b/src/components/post/Post/index.jsx
@@ -53,3 +53,5 @@ export function Post({ data, setIsVisibleModal, setPostId, setIsMyPost }) {
     </S.Post>
   );
 }
+
+export const MemoizedPost = React.memo(Post);

--- a/src/components/post/PostList/index.jsx
+++ b/src/components/post/PostList/index.jsx
@@ -1,5 +1,5 @@
 import * as S from './style';
-import { Post } from '../Post';
+import { Post, MemoizedPost } from '../Post';
 import useHeight from '../../../hooks/useHeight';
 
 export function PostList({ posts, setIsVisibleModal, setPostId }) {
@@ -8,7 +8,7 @@ export function PostList({ posts, setIsVisibleModal, setPostId }) {
   return (
     <S.Container ref={container} height={height}>
       {posts.map((data) => (
-        <Post key={data.id} data={data} setIsVisibleModal={setIsVisibleModal} setPostId={setPostId} />
+        <MemoizedPost key={data.id} data={data} setIsVisibleModal={setIsVisibleModal} setPostId={setPostId} />
       ))}
     </S.Container>
   );

--- a/src/pages/HomePage/index.jsx
+++ b/src/pages/HomePage/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { PostList, NoFollowings, HeaderMain, OthersPostCommentModal } from '../../components';
+import { PostList, NoFollowings, HeaderMain, OthersPostCommentModal, Loading } from '../../components';
 import { getHomeFeeds } from '../../api';
 import useIntersect from '../../hooks/useIntersect';
 
@@ -32,20 +32,21 @@ export function HomePage() {
     setHasNextPage(posts.length === 10);
     page.current += 1;
     setPosts((prev) => [...prev, ...posts]);
+
     setIsLoading(false);
   };
-
-  if (isLoading) return <div>로딩중...</div>;
 
   return (
     <section>
       <h2 className='sr-only'>빵굿빵굿 피드</h2>
       <HeaderMain />
-      {!posts.length ? (
+      {isLoading && <Loading />}
+      {!isLoading && !posts.length ? (
         <NoFollowings />
       ) : (
         <PostList posts={posts} setIsVisibleModal={setIsVisibleModal} setPostId={setPostId} />
       )}
+
       <div ref={ref}></div>
       {isVisibleModal && <OthersPostCommentModal setIsVisibleModal={setIsVisibleModal} postId={postId} />}
     </section>


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## 📋 작업사항

- [x]  홈페이지 무한 스크롤 시 맨위로 올라가는 현상 해결
- [x] 로딩 컴포넌트 생성
- [x] 게시글 컴포넌트 렌더링 최적화

## 🍞 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
- 재사용을 고려해 로딩 컴포넌트 분리했습니다.
- 현상 분석 중에 Profiler 도구로 홈페이지 성능 측정을 진행한 결과, 같은 게시글 컴포넌트가 여러번 렌더링되는 것을 발견했습니다. 이를 React.memo를 통해 컴포넌트를 메모이징하여 이를 재사용하도록 했습니다.

## 💻 스크린샷
<!-- 이미지나 작업내용을 공유해주세요 -->
<img width="390" alt="스크린샷 2023-01-27 오전 12 04 05" src="https://user-images.githubusercontent.com/79586634/214873335-c0d07048-cd2c-473f-afa3-82621f4b8809.png">

Closes #173 
